### PR TITLE
Dev.html ahora apunta a Mapea 5.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,6 @@ Plugin que incorpora una rosa de vientos que se desplaza y gira con el mapa.
 olMap.on('postcompose', e => this.drawWindRose(e));
 ```
 
-## Otros métodos
-
-
 ## Ejemplos de uso
 
 ### Ejemplo 1

--- a/test/dev.html
+++ b/test/dev.html
@@ -7,8 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="mapea" content="yes">
     <title>Windrose TEST</title>
-    <link href="http://sigc-dev.desarrollo.guadaltel.es/mapea5/assets/css/mapea-5.2.0.ol.min.css" rel="stylesheet" />
-    <link href="../dist/windrose.ol.min.css" rel="stylesheet" />
+    <link href="http://mapea4-sigc.juntadeandalucia.es/mapea/assets/css/mapea-5.1.0.ol.min.css" rel="stylesheet" />
     <style rel="stylesheet">
         html,
         body {
@@ -23,20 +22,9 @@
 
 <body>
     <div id="mapjs" class="container"></div>
-    <script type="text/javascript" src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/mapea-5.2.0.ol.min.js"></script>
-    <script type="text/javascript" src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/configuration-5.2.0.js"></script>
-    <script type="text/javascript" src="../dist/windrose.ol.min.js"></script>
-    <script>
-        const map = M.map({
-            container: 'mapjs'
-        });
-
-        const mp = new M.plugin.Windrose({
-            position: 'TC',
-        });
-
-        map.addPlugin(mp);
-    </script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/mapea-5.1.0.ol.min.js"></script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/configuration-5.1.0.js"></script>
+    <script type="text/javascript" src="/main.js"></script>
 </body>
 
 </html>

--- a/test/prod.html
+++ b/test/prod.html
@@ -30,11 +30,7 @@
       const map = M.map({
         container: 'mapjs'
       });
-
-      const mp = new M.plugin.Windrose({
-        position: 'TC',
-      });
-
+      const mp = new M.plugin.Windrose();
       map.addPlugin(mp);
     </script>
   </body>


### PR DESCRIPTION
Corregidos los enlaces de dev.html para que apunte a la versión 5.1 de Mapea.